### PR TITLE
adds ARC compliancy, marks unused variable

### DIFF
--- a/F.h
+++ b/F.h
@@ -29,7 +29,7 @@ typedef NSComparisonResult (^CompareDictBlock) (id k1, id v1 , id k2, id v2);
 typedef void (^VoidBlock) ();
 
 
-static BOOL F_concurrently = NO;
+static BOOL F_concurrently __unused = NO;
 
 
 @interface F : NSObject

--- a/F.m
+++ b/F.m
@@ -94,7 +94,6 @@ static dispatch_queue_t F_queue;
             [mutArr replaceObjectAtIndex:i withObject:o];
             dispatch_semaphore_signal(itemLock);
         });
-        dispatch_release(itemLock);
     }
     else {
         for (id obj in arr) {
@@ -117,7 +116,6 @@ static dispatch_queue_t F_queue;
             [mutDict setValue:map_o forKey:key];
             dispatch_semaphore_signal(itemLock);
         });
-        dispatch_release(itemLock);
     }
     else {
         for (id key in dict) {
@@ -159,7 +157,6 @@ static dispatch_queue_t F_queue;
             }
         });
         [nilArray removeObjectIdenticalTo:[NSNull null]];
-        dispatch_release(itemLock);
         return [NSArray arrayWithArray:nilArray];
     }
     else {
@@ -185,7 +182,6 @@ static dispatch_queue_t F_queue;
                 dispatch_semaphore_signal(itemLock);
             }
         });
-        dispatch_release(itemLock);
     }
     else {
         for (id key in dict) {
@@ -211,7 +207,6 @@ static dispatch_queue_t F_queue;
             }
         });
         [nilArray removeObjectIdenticalTo:[NSNull null]];
-        dispatch_release(itemLock);
         return [NSArray arrayWithArray:nilArray];
     }
     else {
@@ -237,7 +232,6 @@ static dispatch_queue_t F_queue;
                 dispatch_semaphore_signal(itemLock);
             }
         });
-        dispatch_release(itemLock);        
     }
     else {
         for (id key in dict) {
@@ -475,7 +469,6 @@ static dispatch_queue_t F_queue;
             [mutArr replaceObjectAtIndex:i withObject:o];
             dispatch_semaphore_signal(itemLock);
         });
-        dispatch_release(itemLock);
     }
     else {
         for (NSInteger i=from; i<to; i++) {


### PR DESCRIPTION
I have removed the dispatch_release() calls which give errors when compiling under ARC.
Also, F_concurrently is marked as __unused to silence a compiler warning.
