### PR TITLE
Fix strict(er) compiler warnings.

### DIFF
--- a/F.h
+++ b/F.h
@@ -29,9 +29,6 @@ typedef NSComparisonResult (^CompareDictBlock) (id k1, id v1 , id k2, id v2);
 typedef void (^VoidBlock) ();
 
 
-static BOOL F_concurrently __unused = NO;
-
-
 @interface F : NSObject
     + (void) useConcurrency;
     + (void) dontUseConcurrency;

--- a/F.m
+++ b/F.m
@@ -10,6 +10,7 @@
 
 @implementation F
 static dispatch_queue_t F_queue;
+static BOOL F_concurrently = NO;
 
 + (void) useConcurrency {
     NSLog(@"ATTENTION - USING CONCURRENCY WILL RESULT IN A NON-SEQUENTIAL EXECUTION OF THE PASSED BLOCKS");
@@ -84,7 +85,7 @@ static dispatch_queue_t F_queue;
     NSMutableArray *mutArr = [NSMutableArray arrayWithCapacity:[arr count]];
 
     if (F_concurrently) {
-        for (int i=0; i < [arr count]; i++) {
+        for (NSUInteger i=0; i < [arr count]; i++) {
             [mutArr addObject:[NSNull null]];
         }
         dispatch_semaphore_t itemLock = dispatch_semaphore_create(1);
@@ -126,14 +127,14 @@ static dispatch_queue_t F_queue;
     return [NSDictionary dictionaryWithDictionary:mutDict];
 }
 
-+ (NSObject *) reduceArray:(NSArray *) arr withBlock:(ReduceArrayBlock) block andInitialMemo:(NSObject *) memo {
++ (NSObject *) reduceArray:(NSArray *) arr withBlock:(ReduceArrayBlock) block andInitialMemo:(__strong id) memo {
     for (id obj in arr) {
         memo = block(memo, obj);
     }
     return memo;
 }
 
-+ (NSObject *) reduceDictionary:(NSDictionary *) dict withBlock:(ReduceDictBlock) block andInitialMemo:(NSObject *) memo {
++ (NSObject *) reduceDictionary:(NSDictionary *) dict withBlock:(ReduceDictBlock) block andInitialMemo:(__strong id) memo {
     for (id key in dict) {
         id obj = [dict objectForKey:key];
         memo = block(memo, key, obj);
@@ -144,7 +145,7 @@ static dispatch_queue_t F_queue;
 + (NSArray *) filterArray:(NSArray *) arr withBlock:(BoolArrayBlock) block {
     if (F_concurrently) {
         NSMutableArray *nilArray = [NSMutableArray arrayWithCapacity:[arr count]];
-        for (int i=0; i < [arr count]; i++) {
+        for (NSUInteger i=0; i < [arr count]; i++) {
             [nilArray addObject:[NSNull null]];
         }
         dispatch_semaphore_t itemLock = dispatch_semaphore_create(1);
@@ -194,7 +195,7 @@ static dispatch_queue_t F_queue;
 + (NSArray *) rejectArray:(NSArray *) arr withBlock:(BoolArrayBlock) block {
     if (F_concurrently) {
         NSMutableArray *nilArray = [NSMutableArray arrayWithCapacity:[arr count]];
-        for (int i=0; i < [arr count]; i++) {
+        for (NSUInteger i=0; i < [arr count]; i++) {
             [nilArray addObject:[NSNull null]];
         }
         dispatch_semaphore_t itemLock = dispatch_semaphore_create(1);

--- a/NSDictionary+F.m
+++ b/NSDictionary+F.m
@@ -22,7 +22,7 @@
     return [F reduceDictionary:self withBlock:block andInitialMemo:memo];
 }
 
-- filter:(BoolDictionaryBlock) block {
+- (id) filter:(BoolDictionaryBlock) block {
     return [F filterDictionary:self withBlock:block];
 }
 


### PR DESCRIPTION
- mismatching variable types (int vs. NSUInteger)
- Variable incorrectly flagged as __unused
- Mismatching .h/.m return and parameter types
